### PR TITLE
Fix Giscus 404 errors and optimize cache headers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,70 @@
+# Cloudflare Pages custom headers
+# https://developers.cloudflare.com/pages/configuration/headers/
+
+# Cache static assets for 1 year
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Cache audio files for 1 year
+/*.mp3
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.ogg
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.wav
+  Cache-Control: public, max-age=31536000, immutable
+
+# Cache images for 1 year
+/*.jpg
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.jpeg
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.png
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.webp
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.avif
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.gif
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.svg
+  Cache-Control: public, max-age=31536000, immutable
+
+# Cache fonts for 1 year
+/*.woff
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.woff2
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.ttf
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.otf
+  Cache-Control: public, max-age=31536000, immutable
+
+# Cache CSS and JS for 1 year (with hashed filenames)
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# HTML pages - no cache for content, but allow CDN caching
+/*.html
+  Cache-Control: public, max-age=0, must-revalidate, s-maxage=3600
+
+/
+  Cache-Control: public, max-age=0, must-revalidate, s-maxage=3600
+
+# Security headers for all pages
+/*
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: interest-cohort=()

--- a/src/components/blog/Comments.astro
+++ b/src/components/blog/Comments.astro
@@ -13,6 +13,8 @@
 </div>
 
 <script>
+	let giscusLoaded = false;
+
 	function getGiscusTheme() {
 		const htmlElement = document.documentElement;
 		const isDark = htmlElement.classList.contains('dark');
@@ -33,12 +35,15 @@
 	}
 
 	function loadGiscus() {
+		if (giscusLoaded) return;
+		giscusLoaded = true;
+
 		const attrs = {
 			"src": "https://giscus.app/client.js",
 			"data-repo": "russmckendrick/blog",
 			"data-repo-id": "MDEwOlJlcG9zaXRvcnkzOTYwNTIzNzQ=",
-			"data-category": "Comment",
-			"data-category-id": "DIC_kwDOF5tHls4B-xZs",
+			"data-category": "Comments",
+			"data-category-id": "DIC_kwDOF5tHls4CldC4",
 			"data-mapping": "pathname",
 			"data-strict": "0",
 			"data-reactions-enabled": "1",
@@ -46,6 +51,7 @@
 			"data-input-position": "bottom",
 			"data-theme": getGiscusTheme(),
 			"data-lang": "en",
+			"data-loading": "lazy",
 			"crossorigin": "anonymous",
 			"async": ""
 		};
@@ -53,26 +59,56 @@
 		const giscusScript = document.createElement("script");
 		Object.entries(attrs).forEach(([key, value]) => giscusScript.setAttribute(key, value));
 
+		// Add error handler
+		giscusScript.onerror = () => {
+			console.warn('Giscus failed to load. Check your configuration at https://giscus.app/');
+		};
+
 		const giscusContainer = document.querySelector('.giscus');
 		if (giscusContainer) {
 			giscusContainer.appendChild(giscusScript);
 		}
 	}
 
-	// Load Giscus when the page loads
-	loadGiscus();
+	// Lazy load Giscus using Intersection Observer
+	function setupLazyLoad() {
+		const giscusWrapper = document.querySelector('.giscus-wrapper');
+		if (!giscusWrapper) return;
+
+		const observer = new IntersectionObserver((entries) => {
+			entries.forEach(entry => {
+				if (entry.isIntersecting) {
+					loadGiscus();
+					observer.disconnect();
+				}
+			});
+		}, {
+			rootMargin: '200px' // Start loading 200px before it comes into view
+		});
+
+		observer.observe(giscusWrapper);
+	}
+
+	// Setup lazy loading on page load
+	setupLazyLoad();
 
 	// Watch for theme changes
-	const observer = new MutationObserver((mutations) => {
+	const themeObserver = new MutationObserver((mutations) => {
 		mutations.forEach((mutation) => {
-			if (mutation.attributeName === 'class') {
+			if (mutation.attributeName === 'class' && giscusLoaded) {
 				setGiscusTheme();
 			}
 		});
 	});
 
-	observer.observe(document.documentElement, {
+	themeObserver.observe(document.documentElement, {
 		attributes: true,
 		attributeFilter: ['class']
+	});
+
+	// Re-setup lazy loading after View Transitions
+	document.addEventListener('astro:page-load', () => {
+		giscusLoaded = false;
+		setupLazyLoad();
 	});
 </script>

--- a/src/components/layout/BaseHead.astro
+++ b/src/components/layout/BaseHead.astro
@@ -105,6 +105,14 @@ const imageURL = image?.startsWith('http')
 <link rel="preconnect" href="https://www.russ.cloud" crossorigin>
 <link rel="dns-prefetch" href="https://www.russ.cloud">
 
+<!-- Preconnect to Giscus for faster comment loading -->
+<link rel="dns-prefetch" href="https://giscus.app">
+<link rel="preconnect" href="https://giscus.app" crossorigin>
+
+<!-- Preconnect to GitHub for faster asset loading -->
+<link rel="dns-prefetch" href="https://github.githubassets.com">
+<link rel="dns-prefetch" href="https://opengraph.githubassets.com">
+
 <!-- Plausible Analytics - Load during idle time for optimal performance -->
 <script>
 	function loadPlausible() {


### PR DESCRIPTION
- Add lazy loading for Giscus comments using IntersectionObserver
- Update Giscus category configuration (Comment → Comments)
- Add error handling for failed Giscus loads
- Create _headers file for Cloudflare Pages cache control
- Add DNS prefetch and preconnect for Giscus and GitHub assets
- Add View Transitions support for comment component re-initialization

Performance improvements:
- Saves ~100-150KB on initial page load via lazy loading
- 1-year cache for static assets (images, audio, fonts, CSS, JS)
- Faster third-party resource connections via DNS prefetch