### PR TITLE
fix: apply CF_IMAGE_PRESETS config to hero and gallery images

### DIFF
--- a/src/components/embeds/LightGalleryNew.astro
+++ b/src/components/embeds/LightGalleryNew.astro
@@ -1,5 +1,6 @@
 ---
 import { LightGallery as AstroLightGallery } from 'astro-lightgallery';
+import { getCFImageUrl, generateCFSrcSet, CF_IMAGE_PRESETS } from '../../utils/cloudflare-images';
 
 interface GalleryImage {
   src: string;
@@ -25,11 +26,32 @@ interface Props {
 }
 
 const { layout, options, enableMetaPlugin = true, debugMeta = false } = Astro.props;
+
+// Transform gallery images to use Cloudflare Image Transformations
+const transformedLayout = {
+  imgs: layout.imgs.map(img => ({
+    // Use high-quality transformed URL for the lightbox view
+    src: getCFImageUrl(img.src, {
+      width: 2048,
+      quality: CF_IMAGE_PRESETS.gallery.quality,
+      format: CF_IMAGE_PRESETS.gallery.format,
+      fit: CF_IMAGE_PRESETS.gallery.fit
+    }),
+    // Use lower quality for thumbnails
+    thumbnail: getCFImageUrl(img.src, {
+      width: 400,
+      quality: CF_IMAGE_PRESETS.gallery.quality,
+      format: CF_IMAGE_PRESETS.gallery.format,
+      fit: 'cover'
+    }),
+    alt: img.alt
+  }))
+};
 ---
 
 <div data-no-swup class="lightgallery-wrapper">
   <AstroLightGallery
-    layout={layout}
+    layout={transformedLayout}
     options={options}
   />
 </div>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -156,11 +156,11 @@ const breadcrumbSchema = createBreadcrumbSchema(
 				as="image"
 				href={getCFImageUrl(displayImage, {
 					width: 1920,
-					quality: 85,
-					format: 'auto',
-					fit: 'cover'
+					quality: CF_IMAGE_PRESETS.hero.quality,
+					format: CF_IMAGE_PRESETS.hero.format,
+					fit: CF_IMAGE_PRESETS.hero.fit
 				})}
-				imagesrcset={generateCFSrcSet(displayImage, CF_IMAGE_PRESETS.hero.widths, 85)}
+				imagesrcset={generateCFSrcSet(displayImage, CF_IMAGE_PRESETS.hero.widths, CF_IMAGE_PRESETS.hero.quality, CF_IMAGE_PRESETS.hero.format)}
 				imagesizes="100vw"
 				fetchpriority="high"
 			/>
@@ -180,11 +180,11 @@ const breadcrumbSchema = createBreadcrumbSchema(
 						<img
 							src={getCFImageUrl(displayImage, {
 								width: 1920,
-								quality: 85,
-								format: 'auto',
-								fit: 'cover'
+								quality: CF_IMAGE_PRESETS.hero.quality,
+								format: CF_IMAGE_PRESETS.hero.format,
+								fit: CF_IMAGE_PRESETS.hero.fit
 							})}
-							srcset={generateCFSrcSet(displayImage, CF_IMAGE_PRESETS.hero.widths, 85)}
+							srcset={generateCFSrcSet(displayImage, CF_IMAGE_PRESETS.hero.widths, CF_IMAGE_PRESETS.hero.quality, CF_IMAGE_PRESETS.hero.format)}
 							sizes="100vw"
 							alt={cover?.alt || title}
 							loading="eager"


### PR DESCRIPTION
- BlogPost.astro: use CF_IMAGE_PRESETS.hero instead of hardcoded quality=85 and format=auto
- LightGalleryNew.astro: add Cloudflare Image Transformations for all gallery images
- Hero images now use quality=60, format=avif per config
- Gallery images now use quality=60, format=avif for both full-size and thumbnails

This ensures all images use the optimized settings defined in CF_IMAGE_PRESETS, resulting in faster page loads with AVIF format and reduced quality settings.