### PR TITLE
fix: reduce image quality for CF_IMAGE_PRESETS to optimize loading times

### DIFF
--- a/src/components/blog/PostCard.astro
+++ b/src/components/blog/PostCard.astro
@@ -86,14 +86,14 @@ const avatarGlowColor = getAvatarGlowColor();
 							src={getCFImageUrl(heroImage, {
 								width: 800,
 								quality: priority ? CF_IMAGE_PRESETS.thumbnailPriority.quality : CF_IMAGE_PRESETS.thumbnail.quality,
-								format: 'avif',
-								fit: 'cover'
+								format: priority ? CF_IMAGE_PRESETS.thumbnailPriority.format : CF_IMAGE_PRESETS.thumbnail.format,
+								fit: priority ? CF_IMAGE_PRESETS.thumbnailPriority.fit : CF_IMAGE_PRESETS.thumbnail.fit
 							})}
 							srcset={generateCFSrcSet(
 								heroImage,
 								priority ? CF_IMAGE_PRESETS.thumbnailPriority.widths : CF_IMAGE_PRESETS.thumbnail.widths,
 								priority ? CF_IMAGE_PRESETS.thumbnailPriority.quality : CF_IMAGE_PRESETS.thumbnail.quality,
-							'avif'
+								priority ? CF_IMAGE_PRESETS.thumbnailPriority.format : CF_IMAGE_PRESETS.thumbnail.format
 							)}
 							sizes="(min-width: 1024px) 728px, (min-width: 768px) 688px, (min-width: 640px) 600px, (min-width: 400px) 360px, 280px"
 							alt={alt}
@@ -173,10 +173,10 @@ const avatarGlowColor = getAvatarGlowColor();
 							src={getCFImageUrl(heroImage, {
 								width: 384,
 								quality: CF_IMAGE_PRESETS.thumbnailHorizontal.quality,
-								format: 'avif',
-								fit: 'cover'
+								format: CF_IMAGE_PRESETS.thumbnailHorizontal.format,
+								fit: CF_IMAGE_PRESETS.thumbnailHorizontal.fit
 							})}
-							srcset={generateCFSrcSet(heroImage, CF_IMAGE_PRESETS.thumbnailHorizontal.widths, CF_IMAGE_PRESETS.thumbnailHorizontal.quality, 'avif')}
+							srcset={generateCFSrcSet(heroImage, CF_IMAGE_PRESETS.thumbnailHorizontal.widths, CF_IMAGE_PRESETS.thumbnailHorizontal.quality, CF_IMAGE_PRESETS.thumbnailHorizontal.format)}
 							sizes="(min-width: 1024px) 256px, (min-width: 768px) 224px, (min-width: 640px) 192px, 100vw"
 							alt={alt}
 							width="512"

--- a/src/components/embeds/Img.astro
+++ b/src/components/embeds/Img.astro
@@ -1,6 +1,6 @@
 ---
 import { LightGallery } from 'astro-lightgallery'
-import { getCFImageUrl, generateCFSrcSet } from '../../utils/cloudflare-images';
+import { getCFImageUrl, generateCFSrcSet, CF_IMAGE_PRESETS } from '../../utils/cloudflare-images';
 
 interface Props {
   src: string;
@@ -19,11 +19,24 @@ const isExternal = src.startsWith('http://') || src.startsWith('https://');
 // Determine if zoom should be enabled
 const enableZoom = zoom === 'true' || zoom === true;
 
-// For local images, use Cloudflare Image Transformations
-// For gallery/zoom, use high quality (90)
-const imgSrc = isExternal ? src : getCFImageUrl(src, { width: 1200, quality: 90, format: 'auto' });
-const highResSrc = isExternal ? src : getCFImageUrl(src, { width: 2048, quality: 90, format: 'auto' });
-const srcsetString = isExternal ? '' : generateCFSrcSet(src, [640, 1024, 1536, 2048], 90);
+// For local images, use Cloudflare Image Transformations with gallery preset
+const imgSrc = isExternal ? src : getCFImageUrl(src, {
+  width: 1200,
+  quality: CF_IMAGE_PRESETS.gallery.quality,
+  format: CF_IMAGE_PRESETS.gallery.format
+});
+const highResSrc = isExternal ? src : getCFImageUrl(src, {
+  width: 2048,
+  quality: CF_IMAGE_PRESETS.gallery.quality,
+  format: CF_IMAGE_PRESETS.gallery.format,
+  fit: CF_IMAGE_PRESETS.gallery.fit
+});
+const srcsetString = isExternal ? '' : generateCFSrcSet(
+  src,
+  CF_IMAGE_PRESETS.gallery.widths,
+  CF_IMAGE_PRESETS.gallery.quality,
+  CF_IMAGE_PRESETS.gallery.format
+);
 ---
 
 <div class="img-wrapper my-6 flex justify-center">


### PR DESCRIPTION
Additional fixes found during code review:
- Img.astro: use CF_IMAGE_PRESETS.gallery (quality=60, format=avif) instead of hardcoded quality=90, format=auto
- PostCard.astro: use preset format/fit values instead of hardcoded 'avif'/'cover' for consistency

All image components now properly reference CF_IMAGE_PRESETS config:
- Hero images: quality=60, format=avif
- Gallery images: quality=60, format=avif
- Thumbnails: quality=30/35, format=avif
- Ensures consistent quality and format settings across all image types