### PR TITLE
feat: implement new tunes page layout with featured post and grid vie…

### DIFF
--- a/src/components/blog/PostCard.astro
+++ b/src/components/blog/PostCard.astro
@@ -10,7 +10,7 @@ import { AI_AUTHOR, TAG_METADATA, TAG_AVATAR_MAP, CF_IMAGE_PRESETS } from '../..
 interface Props {
 	post: CollectionEntry<'blog'> | CollectionEntry<'tunes'>;
 	priority?: boolean; // For LCP optimization on first card
-	variant?: 'vertical' | 'horizontal'; // Layout variant
+	variant?: 'vertical' | 'horizontal' | 'featured' | 'grid'; // Layout variant
 	headingLevel?: '2' | '3'; // Heading level for accessibility
 }
 
@@ -176,7 +176,178 @@ const lqipUrl = heroImage ? getLQIPUrl(heroImage) : null;
 			</div>
 		</article>
 	</a>
+) : variant === 'featured' ? (
+	/* Featured variant - Side-by-side asymmetric layout for hero section */
+	<a
+		href={href}
+		aria-label={`Read blog post: ${post.data.title}`}
+		class="group block focus:outline-none focus-visible:ring-4 focus-visible:ring-blue-500/60 focus-visible:ring-offset-[16px] focus-visible:ring-offset-gray-100 dark:focus-visible:ring-offset-gray-900 rounded-3xl">
+		<article
+			class="relative bg-white/95 dark:bg-gray-900/70 border border-gray-200/60 dark:border-gray-700 rounded-3xl shadow-xl dark:shadow-black/40 overflow-hidden transition-all duration-500 group-hover:shadow-2xl">
+			<div class="flex flex-col lg:flex-row">
+				{/* Content side */}
+				<div class="relative p-8 lg:p-10 xl:p-12 flex flex-col gap-6 lg:w-1/2 order-2 lg:order-1">
+					<header class="space-y-4">
+						<HeadingTag class="text-3xl lg:text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100 leading-tight">
+							{post.data.title}
+						</HeadingTag>
+					</header>
+					{description && (
+						<p class="text-lg text-gray-600 dark:text-gray-300 leading-relaxed">
+							{description}
+						</p>
+					)}
+					<footer class="mt-auto pt-4 text-sm flex flex-wrap items-center gap-x-4 gap-y-3">
+						<div class="flex items-center gap-3">
+							<div class="relative flex-shrink-0">
+								<div class={`absolute -inset-0.5 bg-gradient-to-r from-current to-current rounded-full opacity-60 blur-sm will-change-transform ${avatarGlowColor}`}></div>
+								<img
+									src={avatarSrc}
+									alt={author}
+									class="relative w-12 h-12 rounded-full ring-2 ring-white dark:ring-gray-900 shadow-md object-cover"
+									onError={`this.onerror=null; this.src='${avatarFallback}';`}
+								/>
+							</div>
+							<div class="flex flex-col">
+								<span class="text-gray-800 dark:text-gray-200 font-semibold">{author}</span>
+								<div class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+									<span class="text-blue-600 dark:text-blue-400">
+										<FormattedDate date={post.data.pubDate} />
+									</span>
+									{readingTime && (
+										<>
+											<span aria-hidden="true">·</span>
+											<span>{readingTime}</span>
+										</>
+									)}
+								</div>
+							</div>
+						</div>
+						{tags.length > 0 && (
+							<div class="flex flex-wrap gap-2 lg:ml-auto">
+								{tags.slice(0, 4).map((tag) => (
+									<span
+										class={`inline-flex items-center rounded-full px-3 py-1.5 text-sm font-medium ${getTagColorClasses(tag)}`}
+									>
+										{getTagDisplayName(tag)}
+									</span>
+								))}
+							</div>
+						)}
+					</footer>
+				</div>
+				{/* Image side */}
+				{heroImage && (
+					<figure
+						class="relative overflow-hidden lg:w-1/2 order-1 lg:order-2 bg-cover bg-center bg-no-repeat"
+						style={lqipUrl ? `background-image: url('${lqipUrl}')` : undefined}
+					>
+						{lqipUrl && (
+							<div
+								class="absolute inset-0 bg-cover bg-center bg-no-repeat blur-lg scale-105 -z-10"
+								style={`background-image: url('${lqipUrl}')`}
+								aria-hidden="true"
+							/>
+						)}
+						<img
+							src={getCFImageUrl(heroImage, {
+								width: priority ? 600 : 800,
+								quality: 85,
+								format: 'auto',
+								fit: 'cover'
+							})}
+							srcset={generateCFSrcSet(heroImage, [400, 600, 800, 1000], 85, 'auto')}
+							sizes="(min-width: 1024px) 50vw, 100vw"
+							alt={alt}
+							width="1000"
+							height="700"
+							loading={priority ? "eager" : "lazy"}
+							decoding={priority ? "sync" : "async"}
+							fetchpriority={priority ? "high" : "low"}
+							class="w-full h-64 sm:h-80 lg:h-full lg:min-h-[400px] object-cover transition-transform duration-700 group-hover:scale-[1.02]"
+						/>
+					</figure>
+				)}
+			</div>
+		</article>
+	</a>
+) : variant === 'grid' ? (
+	/* Grid variant - Compact card for 3-column layouts */
+	<a
+		href={href}
+		aria-label={`Read blog post: ${post.data.title}`}
+		class="group block focus:outline-none focus-visible:ring-4 focus-visible:ring-blue-500/60 focus-visible:ring-offset-4 focus-visible:ring-offset-gray-100 dark:focus-visible:ring-offset-gray-900 rounded-2xl h-full">
+		<article
+			class="relative bg-white/95 dark:bg-gray-900/70 border border-gray-200/60 dark:border-gray-700 rounded-2xl shadow-lg dark:shadow-black/30 overflow-hidden transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-xl h-full flex flex-col">
+			{heroImage && (
+				<figure
+					class="relative overflow-hidden bg-cover bg-center bg-no-repeat"
+					style={lqipUrl ? `background-image: url('${lqipUrl}')` : undefined}
+				>
+					{lqipUrl && (
+						<div
+							class="absolute inset-0 bg-cover bg-center bg-no-repeat blur-lg scale-105 -z-10"
+							style={`background-image: url('${lqipUrl}')`}
+							aria-hidden="true"
+						/>
+					)}
+					<img
+						src={getCFImageUrl(heroImage, {
+							width: 400,
+							quality: 80,
+							format: 'auto',
+							fit: 'cover'
+						})}
+						srcset={generateCFSrcSet(heroImage, [300, 400, 500], 80, 'auto')}
+						sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+						alt={alt}
+						width="500"
+						height="375"
+						loading="lazy"
+						decoding="async"
+						fetchpriority="low"
+						class="w-full aspect-[4/3] object-cover transition-transform duration-700 group-hover:scale-[1.03]"
+					/>
+				</figure>
+			)}
+			<div class="relative p-5 flex flex-col gap-3 flex-1">
+				{tags.length > 0 && (
+					<div class="flex flex-wrap gap-1.5">
+						{tags.slice(0, 2).map((tag) => (
+							<span
+								class={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${getTagColorClasses(tag)}`}
+							>
+								{getTagDisplayName(tag)}
+							</span>
+						))}
+					</div>
+				)}
+				<header>
+					<HeadingTag class="text-base font-semibold tracking-tight text-gray-900 dark:text-gray-100 leading-snug">
+						{post.data.title}
+					</HeadingTag>
+				</header>
+				{description && (
+					<p class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed line-clamp-2">
+						{description}
+					</p>
+				)}
+				<footer class="mt-auto pt-2 text-xs flex items-center gap-2 text-gray-500 dark:text-gray-400">
+					<span class="text-blue-600 dark:text-blue-400 font-medium">
+						<FormattedDate date={post.data.pubDate} />
+					</span>
+					{readingTime && (
+						<>
+							<span aria-hidden="true">·</span>
+							<span>{readingTime}</span>
+						</>
+					)}
+				</footer>
+			</div>
+		</article>
+	</a>
 ) : (
+	/* Horizontal variant - Side-by-side for related posts */
 	<a
 		href={href}
 		aria-label={`Read blog post: ${post.data.title}`}

--- a/src/components/home/CategoryPills.astro
+++ b/src/components/home/CategoryPills.astro
@@ -1,0 +1,21 @@
+---
+import { getTagUrl, getTagDisplayName, getTagColorClasses } from '../../utils/tags';
+
+interface Props {
+	tags: string[];
+	class?: string;
+}
+
+const { tags, class: className = '' } = Astro.props;
+---
+
+<nav aria-label="Category navigation" class={`flex flex-wrap justify-center gap-2 sm:gap-3 ${className}`}>
+	{tags.map((tag) => (
+		<a
+			href={getTagUrl(tag)}
+			class={`inline-flex items-center rounded-full px-4 py-2 text-sm font-medium ${getTagColorClasses(tag)} transition-all duration-300 hover:scale-105 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:ring-offset-2 focus:ring-offset-gray-50 dark:focus:ring-offset-gray-900`}
+		>
+			{getTagDisplayName(tag)}
+		</a>
+	))}
+</nav>

--- a/src/components/home/HeroSection.astro
+++ b/src/components/home/HeroSection.astro
@@ -1,0 +1,15 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import PostCard from '../blog/PostCard.astro';
+
+interface Props {
+	featuredPost: CollectionEntry<'blog'> | CollectionEntry<'tunes'>;
+}
+
+const { featuredPost } = Astro.props;
+---
+
+<section>
+	{/* Featured Post - Side-by-side layout */}
+	<PostCard post={featuredPost} variant="featured" priority={true} headingLevel="2" />
+</section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,11 +2,14 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import PostCard from '../components/blog/PostCard.astro';
+import HeroSection from '../components/home/HeroSection.astro';
 import Pagination from '../components/layout/Pagination.astro';
 import { SITE_TITLE, SITE_DESCRIPTION, CF_IMAGE_PRESETS } from '../consts';
 import { getHeroColors, gradientStylesToString, getGradientStyles } from '../utils/hero-colors';
 import { getCFImageUrl, generateCFSrcSet } from '../utils/cloudflare-images';
-const postsPerPage = 5;
+
+// Homepage shows 1 featured + 6 grid cards = 7 total
+const postsPerPage = 7;
 
 const allPosts = (await getCollection('blog'))
 	.filter(post => import.meta.env.DEV || !post.data.draft)
@@ -15,15 +18,18 @@ const allPosts = (await getCollection('blog'))
 const posts = allPosts.slice(0, postsPerPage);
 const totalPages = Math.ceil(allPosts.length / postsPerPage);
 
+// Split posts: first for hero, rest for grid
+const featuredPost = posts[0];
+const gridPosts = posts.slice(1);
+
 // Get first post hero image for LCP preload optimization
 // Use Cloudflare image transformation to match what PostCard uses
-const firstPost = posts[0];
-const firstPostHeroImage = firstPost?.data.heroImage || firstPost?.data.cover?.image;
+const firstPostHeroImage = featuredPost?.data.heroImage || featuredPost?.data.cover?.image;
 const preloadSrcSet = firstPostHeroImage ? generateCFSrcSet(
 	firstPostHeroImage,
-	CF_IMAGE_PRESETS.thumbnailPriority.widths,
-	CF_IMAGE_PRESETS.thumbnailPriority.quality,
-	CF_IMAGE_PRESETS.thumbnailPriority.format
+	[400, 600, 800, 1000], // Match featured variant srcset
+	85,
+	'auto'
 ) : null;
 
 // Get gradient colors from first post's hero image
@@ -38,7 +44,7 @@ const gradientStyleString = gradientStylesToString(getGradientStyles(heroColors)
 			rel="preload"
 			as="image"
 			imagesrcset={preloadSrcSet}
-			imagesizes="(min-width: 768px) 720px, calc(100vw - 48px)"
+			imagesizes="(min-width: 1024px) 50vw, 100vw"
 			fetchpriority="high"
 		/>
 	)}
@@ -49,20 +55,29 @@ const gradientStyleString = gradientStylesToString(getGradientStyles(heroColors)
 	>
 		<div class="hero-gradient-bg absolute inset-0"></div>
 	</section>
-	<section class="max-w-3xl mx-auto px-5">
-		<h1 class="sr-only">{SITE_TITLE}</h1>
-		<ul class="space-y-12">
-			{posts.map((post, index) => (
-				<li>
-					<PostCard post={post} priority={index === 0} />
-				</li>
-			))}
-		</ul>
 
-			<Pagination
-				currentPage={1}
-				totalPages={totalPages}
-				getHref={(pageNum) => (pageNum === 1 ? '/' : `/page/${pageNum}/`)}
-			/>
-		</section>
+	<section class="max-w-6xl mx-auto px-5">
+		<h1 class="sr-only">{SITE_TITLE}</h1>
+
+		{/* Hero Section with Featured Post */}
+		<HeroSection featuredPost={featuredPost} />
+
+		{/* Grid of remaining posts */}
+		{gridPosts.length > 0 && (
+			<div class="mt-8 sm:mt-10">
+				<h2 class="sr-only">More Posts</h2>
+				<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8 items-stretch">
+					{gridPosts.map((post) => (
+						<PostCard post={post} variant="grid" headingLevel="3" />
+					))}
+				</div>
+			</div>
+		)}
+
+		<Pagination
+			currentPage={1}
+			totalPages={totalPages}
+			getHref={(pageNum) => (pageNum === 1 ? '/' : `/page/${pageNum}/`)}
+		/>
+	</section>
 </BaseLayout>

--- a/src/pages/page/[...page].astro
+++ b/src/pages/page/[...page].astro
@@ -3,47 +3,28 @@ import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import PostCard from '../../components/blog/PostCard.astro';
 import Pagination from '../../components/layout/Pagination.astro';
-import { SITE_TITLE, SITE_DESCRIPTION, CF_IMAGE_PRESETS } from '../../consts';
+import { SITE_TITLE, SITE_DESCRIPTION } from '../../consts';
 import { getHeroColors, gradientStylesToString, getGradientStyles } from '../../utils/hero-colors';
-import { getCFImageUrl, generateCFSrcSet } from '../../utils/cloudflare-images';
 
 export async function getStaticPaths({ paginate }) {
 	const allPosts = (await getCollection('blog'))
 		.filter(post => import.meta.env.DEV || !post.data.draft)
 		.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
-	return paginate(allPosts, { pageSize: 5 });
+	// 9 posts per page fills 3 rows nicely in the grid
+	return paginate(allPosts, { pageSize: 9 });
 }
 
 const { page } = Astro.props;
 
-// Get first post hero image for LCP preload optimization
-// Use Cloudflare image transformation to match what PostCard uses
+// Get gradient colors from first post's hero image
 const firstPost = page.data[0];
 const firstPostHeroImage = firstPost?.data.heroImage || firstPost?.data.cover?.image;
-const preloadSrcSet = firstPostHeroImage ? generateCFSrcSet(
-	firstPostHeroImage,
-	CF_IMAGE_PRESETS.thumbnailPriority.widths,
-	CF_IMAGE_PRESETS.thumbnailPriority.quality,
-	CF_IMAGE_PRESETS.thumbnailPriority.format
-) : null;
-
-// Get gradient colors from first post's hero image
 const heroColors = getHeroColors(firstPostHeroImage);
 const gradientStyleString = gradientStylesToString(getGradientStyles(heroColors));
 ---
 
 <BaseLayout title={`${SITE_TITLE} - Page ${page.currentPage}`} description={SITE_DESCRIPTION}>
-	{preloadSrcSet && (
-		<link
-			slot="head"
-			rel="preload"
-			as="image"
-			imagesrcset={preloadSrcSet}
-			imagesizes="(min-width: 768px) 720px, calc(100vw - 40px)"
-			fetchpriority="high"
-		/>
-	)}
 	<!-- Hero gradient background from first post -->
 	<section
 		class="hero-gradient-section absolute inset-x-0 top-0 -z-10 h-[70vh] min-h-[450px]"
@@ -51,23 +32,24 @@ const gradientStyleString = gradientStylesToString(getGradientStyles(heroColors)
 	>
 		<div class="hero-gradient-bg absolute inset-0"></div>
 	</section>
-	<section class="max-w-3xl mx-auto px-5">
-		<h1 class="sr-only">{SITE_TITLE} - Page {page.currentPage}</h1>
-		<ul class="space-y-12">
-			{page.data.map((post, index) => (
-				<li>
-					<PostCard post={post} priority={index === 0} />
-				</li>
-			))}
-			</ul>
 
-			{page.total > page.size && (
-				<Pagination
-					currentPage={page.currentPage}
-					totalPages={page.lastPage}
-					getHref={(pageNum) => (pageNum === 1 ? '/' : `/page/${pageNum}/`)}
-					hideIfSingle={false}
-				/>
-			)}
-		</section>
+	<section class="max-w-6xl mx-auto px-5">
+		<h1 class="sr-only">{SITE_TITLE} - Page {page.currentPage}</h1>
+
+		{/* 3-column grid of posts */}
+		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8 items-stretch">
+			{page.data.map((post) => (
+				<PostCard post={post} variant="grid" headingLevel="2" />
+			))}
+		</div>
+
+		{page.total > page.size && (
+			<Pagination
+				currentPage={page.currentPage}
+				totalPages={page.lastPage}
+				getHref={(pageNum) => (pageNum === 1 ? '/' : `/page/${pageNum}/`)}
+				hideIfSingle={false}
+			/>
+		)}
+	</section>
 </BaseLayout>

--- a/src/pages/tunes/index.astro
+++ b/src/pages/tunes/index.astro
@@ -2,21 +2,30 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import PostCard from '../../components/blog/PostCard.astro';
+import HeroSection from '../../components/home/HeroSection.astro';
 import Pagination from '../../components/layout/Pagination.astro';
 import { getHeroColors, gradientStylesToString, getGradientStyles } from '../../utils/hero-colors';
 
-const postsPerPage = 20;
+// Tunes homepage shows 1 featured + 6 grid cards = 7 total
+const firstPagePosts = 7;
+// Subsequent pages show 9 posts each (3 rows of 3)
+const subsequentPagePosts = 9;
 
 const allTunes = (await getCollection('tunes'))
 	.filter(tune => !tune.data.draft)
 	.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
-const tunes = allTunes.slice(0, postsPerPage);
-const totalPages = Math.ceil(allTunes.length / postsPerPage);
+const tunes = allTunes.slice(0, firstPagePosts);
+// Calculate total pages accounting for different first page size
+const remainingPosts = allTunes.length - firstPagePosts;
+const totalPages = 1 + Math.ceil(Math.max(0, remainingPosts) / subsequentPagePosts);
+
+// Split posts: first for hero, rest for grid
+const featuredTune = tunes[0];
+const gridTunes = tunes.slice(1);
 
 // Get gradient colors from first tunes post's hero image
-const firstPost = tunes[0];
-const firstPostHeroImage = firstPost?.data.heroImage || firstPost?.data.cover?.image;
+const firstPostHeroImage = featuredTune?.data.heroImage || featuredTune?.data.cover?.image;
 const heroColors = getHeroColors(firstPostHeroImage);
 const gradientStyleString = gradientStylesToString(getGradientStyles(heroColors));
 ---
@@ -29,23 +38,24 @@ const gradientStyleString = gradientStylesToString(getGradientStyles(heroColors)
 	>
 		<div class="hero-gradient-bg absolute inset-0"></div>
 	</section>
-	<section class="max-w-3xl mx-auto px-5">
-		<div class="mb-12 text-center">
-			<h1 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold leading-tight tracking-tight text-gray-900 dark:text-gray-100 mb-4">
-				Listened to This Week
-			</h1>
-			<p class="text-lg text-gray-600 dark:text-gray-400">
-				My weekly music discoveries and favorites
-			</p>
-		</div>
 
-		<ul class="space-y-12">
-			{tunes.map((tune) => (
-				<li>
-					<PostCard post={tune} />
-				</li>
-			))}
-		</ul>
+	<section class="max-w-6xl mx-auto px-5">
+		<h1 class="sr-only">Listened to This Week</h1>
+
+		{/* Hero Section with Featured Tune */}
+		<HeroSection featuredPost={featuredTune} />
+
+		{/* Grid of remaining tunes */}
+		{gridTunes.length > 0 && (
+			<div class="mt-8 sm:mt-10">
+				<h2 class="sr-only">More Tunes</h2>
+				<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8 items-stretch">
+					{gridTunes.map((tune) => (
+						<PostCard post={tune} variant="grid" headingLevel="3" />
+					))}
+				</div>
+			</div>
+		)}
 
 		<Pagination
 			currentPage={1}

--- a/src/pages/tunes/page/[page].astro
+++ b/src/pages/tunes/page/[page].astro
@@ -7,18 +7,23 @@ import Pagination from '../../../components/layout/Pagination.astro';
 import { getHeroColors, gradientStylesToString, getGradientStyles } from '../../../utils/hero-colors';
 
 export const getStaticPaths = (async ({ paginate }) => {
-	const postsPerPage = 20;
+	// 9 posts per page fills 3 rows nicely in the grid
+	const postsPerPage = 9;
+	// First page shows 7 (1 featured + 6 grid)
+	const firstPagePosts = 7;
 
 	const allTunes = (await getCollection('tunes'))
 		.filter(tune => !tune.data.draft)
 		.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 
-	const totalPages = Math.ceil(allTunes.length / postsPerPage);
+	// Calculate total pages accounting for different first page size
+	const remainingPosts = allTunes.length - firstPagePosts;
+	const totalPages = 1 + Math.ceil(Math.max(0, remainingPosts) / postsPerPage);
 
 	// Generate paths for pages 2 and onwards (page 1 is handled by /tunes/index.astro)
-	return Array.from({ length: totalPages - 1 }, (_, i) => {
+	return Array.from({ length: Math.max(0, totalPages - 1) }, (_, i) => {
 		const pageNum = i + 2;
-		const start = (pageNum - 1) * postsPerPage;
+		const start = firstPagePosts + (pageNum - 2) * postsPerPage;
 		const end = start + postsPerPage;
 
 		return {
@@ -49,28 +54,24 @@ const gradientStyleString = gradientStylesToString(getGradientStyles(heroColors)
 	>
 		<div class="hero-gradient-bg absolute inset-0"></div>
 	</section>
-	<section class="max-w-3xl mx-auto px-5">
-		<div class="mb-12 text-center">
-			<h1 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold leading-tight tracking-tight text-gray-900 dark:text-gray-100 mb-4">
-				Listened to This Week
-			</h1>
-			<p class="text-lg text-gray-600 dark:text-gray-400">
-				My weekly music discoveries and favorites
-			</p>
+
+	<section class="max-w-6xl mx-auto px-5">
+		<h1 class="sr-only">Listened to This Week - Page {currentPage}</h1>
+
+		{/* 3-column grid of tunes */}
+		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8 items-stretch">
+			{tunes.map((tune) => (
+				<PostCard post={tune} variant="grid" headingLevel="2" />
+			))}
 		</div>
 
-		<ul class="space-y-12">
-			{tunes.map((tune) => (
-				<li>
-					<PostCard post={tune} />
-				</li>
-			))}
-		</ul>
-
-		<Pagination
-			currentPage={currentPage}
-			totalPages={totalPages}
-			getHref={(pageNum) => (pageNum === 1 ? '/tunes/' : `/tunes/page/${pageNum}/`)}
-		/>
+		{totalPages > 1 && (
+			<Pagination
+				currentPage={currentPage}
+				totalPages={totalPages}
+				getHref={(pageNum) => (pageNum === 1 ? '/tunes/' : `/tunes/page/${pageNum}/`)}
+				hideIfSingle={false}
+			/>
+		)}
 	</section>
 </BaseLayout>


### PR DESCRIPTION
This pull request introduces a significant redesign of the homepage, tunes, and paginated listing pages to feature a prominent "featured" post/tune at the top and display remaining content in a responsive 3-column grid. It also adds new layout variants to the `PostCard` component and introduces reusable UI components for category navigation and hero sections. The changes improve both the visual hierarchy and accessibility of the site.

**Homepage and Tunes Redesign:**

- The homepage and `/tunes` now show a single featured post/tune at the top using a new "featured" layout, with the remaining posts/tunes displayed in a 3-column grid below. The first page shows 1 featured + 6 grid cards, and subsequent pages show 9 grid cards per page. [[1]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663R21-R32)], [[2]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L52-R75)], [[3]](diffhunk://#diff-1aa27cd78c27c745ba3ebe7f8f868228ad4ed021049ddcf084655bfd533abd79R5-R28)], [[4]](diffhunk://#diff-1aa27cd78c27c745ba3ebe7f8f868228ad4ed021049ddcf084655bfd533abd79L32-R58)], [[src/pages/tunes/page/[page].astroL10-R26](diffhunk://#diff-7d6cecc3093768c9e5747d3f0b332c80b956f63cc1ed6963355a5e93afb45ac2L10-R26)], [[src/pages/tunes/page/[page].astroL52-R75](diffhunk://#diff-7d6cecc3093768c9e5747d3f0b332c80b956f63cc1ed6963355a5e93afb45ac2L52-R75)])

- The paginated blog and tunes pages now use a 3-column grid layout for consistency and improved readability. ([[src/pages/page/[...page].astroL6-R44](diffhunk://#diff-6eb8542daedfa8345c1ac5f614c34db67ad0d21f9b57ca57050697d41f92009eL6-R44)])

**Component and Layout Enhancements:**

- Added a new `HeroSection.astro` component to render the featured post/tune in a visually distinct side-by-side layout. ([[src/components/home/HeroSection.astroR1-R15](diffhunk://#diff-1c1cb726e25afff12da943ce3c9f06654e39797aa2cdbf8a3bc30bd85832ab7dR1-R15)])

- Introduced a new `CategoryPills.astro` component for displaying tag/category navigation as pill-shaped links. ([[src/components/home/CategoryPills.astroR1-R21](diffhunk://#diff-485a4cda39f8d0e2ee90a3f1c95558d1ff7921aed72c6ce888d5881b63c8359dR1-R21)])

**PostCard Component Improvements:**

- Extended the `PostCard` component to support new `variant` options: `'featured'` (side-by-side hero layout) and `'grid'` (compact card for grid layouts), in addition to existing `'vertical'` and `'horizontal'` variants. [[1]](diffhunk://#diff-84729f966f5305e61c88e3aee49129f0d1ebdf7f120ecf4e0a7d9f5082880f58L13-R13)], [[2]](diffhunk://#diff-84729f966f5305e61c88e3aee49129f0d1ebdf7f120ecf4e0a7d9f5082880f58R179-R350)])

**Accessibility and Visual Improvements:**

- Updated heading levels and added visually hidden headings for improved accessibility. [[1]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L52-R75)], [[2]](diffhunk://#diff-1aa27cd78c27c745ba3ebe7f8f868228ad4ed021049ddcf084655bfd533abd79L32-R58)], [[src/pages/tunes/page/[page].astroL52-R75](diffhunk://#diff-7d6cecc3093768c9e5747d3f0b332c80b956f63cc1ed6963355a5e93afb45ac2L52-R75)])

- Adjusted image preloading and responsive image sizes to match the new layouts for better performance and LCP optimization. ([[src/pages/index.astroL41-R47](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L41-R47)])

---

**Homepage and Tunes Redesign**
- Homepage and `/tunes` now display a featured post/tune at the top with a new "featured" layout, followed by a 3-column grid of remaining items. Pagination logic was updated to accommodate this split. [[1]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663R21-R32)], [[2]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L52-R75)], [[3]](diffhunk://#diff-1aa27cd78c27c745ba3ebe7f8f868228ad4ed021049ddcf084655bfd533abd79R5-R28)], [[4]](diffhunk://#diff-1aa27cd78c27c745ba3ebe7f8f868228ad4ed021049ddcf084655bfd533abd79L32-R58)], [[src/pages/tunes/page/[page].astroL10-R26](diffhunk://#diff-7d6cecc3093768c9e5747d3f0b332c80b956f63cc1ed6963355a5e93afb45ac2L10-R26)], [[src/pages/tunes/page/[page].astroL52-R75](diffhunk://#diff-7d6cecc3093768c9e5747d3f0b332c80b956f63cc1ed6963355a5e93afb45ac2L52-R75)])
- Paginated blog and tunes listing pages now use a consistent 3-column grid layout. ([[src/pages/page/[...page].astroL6-R44](diffhunk://#diff-6eb8542daedfa8345c1ac5f614c34db67ad0d21f9b57ca57050697d41f92009eL6-R44)])

**Component and Layout Enhancements**
- Added `HeroSection.astro` for rendering the featured post/tune in a prominent side-by-side layout. ([[src/components/home/HeroSection.astroR1-R15](diffhunk://#diff-1c1cb726e25afff12da943ce3c9f06654e39797aa2cdbf8a3bc30bd85832ab7dR1-R15)])
- Added `CategoryPills.astro` for reusable tag/category navigation UI. ([[src/components/home/CategoryPills.astroR1-R21](diffhunk://#diff-485a4cda39f8d0e2ee90a3f1c95558d1ff7921aed72c6ce888d5881b63c8359dR1-R21)])

**PostCard Component Improvements**
- Extended `PostCard` to support `featured` and `grid` variants for new layouts. [[1]](diffhunk://#diff-84729f966f5305e61c88e3aee49129f0d1ebdf7f120ecf4e0a7d9f5082880f58L13-R13)], [[2]](diffhunk://#diff-84729f966f5305e61c88e3aee49129f0d1ebdf7f120ecf4e0a7d9f5082880f58R179-R350)])

**Accessibility and Visual Improvements**
- Improved heading structure and added screen-reader-only headings for accessibility. [[1]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L52-R75)], [[2]](diffhunk://#diff-1aa27cd78c27c745ba3ebe7f8f868228ad4ed021049ddcf084655bfd533abd79L32-R58)], [[src/pages/tunes/page/[page].astroL52-R75](diffhunk://#diff-7d6cecc3093768c9e5747d3f0b332c80b956f63cc1ed6963355a5e93afb45ac2L52-R75)])
- Updated image preload and responsive sizing for better LCP and layout performance. ([[src/pages/index.astroL41-R47](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L41-R47)])